### PR TITLE
Fix baseControl hanging when yarpserver is not running.

### DIFF
--- a/src/baseControl/main.cpp
+++ b/src/baseControl/main.cpp
@@ -414,6 +414,15 @@ public:
 /////////////////////////////////////////////////////////////////
 int main(int argc, char *argv[])
 {
+    //Initialize Yarp network
+    Network yarp;
+
+    if (!yarp.checkNetwork())
+    {
+        std::cerr << "Sorry YARP network does not seem to be available, is the yarp server available?\n";
+        return -1;
+    }
+
     ResourceFinder rf;
     rf.setVerbose(true);
     rf.setDefaultContext("navigation");
@@ -430,15 +439,6 @@ int main(int argc, char *argv[])
         yInfo("'joystick_connect' tries to automatically connect to the joystickCtrl output.");
         yInfo("'skip_robot_interface_check' does not connect to robotInterface/rpc (useful for simulator)");
         return 0;
-    }
-
-    //Initialize Yarp network
-    Network yarp;
-
-    if (!yarp.checkNetwork())
-    {
-        yError("Sorry YARP network does not seem to be available, is the yarp server available?\n");
-        return -1;
     }
 
     //Starts the control module


### PR DESCRIPTION
Just moved `yarp check network` as first statement before using resource finder.
Removed `yError`, because in case `yarp_log_forward` is set to `true`, it requires yarp port to forward the message, but in this case the yarpserver is not found, so cannot be used and creates problemes.