### PR TITLE
Follow predefined path in locations.ini in ros2Navigator

### DIFF
--- a/src/navigationDevices/navigationDeviceTemplate/navigationDeviceTemplate.h
+++ b/src/navigationDevices/navigationDeviceTemplate/navigationDeviceTemplate.h
@@ -74,6 +74,13 @@ public:
     bool gotoTargetByRelativeLocation(double x, double y, double theta) override;
 
     /**
+     * Ask the robot to pass through a set of locations defined in the world reference frame
+     * @param path the path to follow
+     * @return true/false
+    */
+    bool followPath(const yarp::dev::Nav2D::Map2DPath& path) override;
+
+    /**
     * //Gets the last target set through a setNewAbsTarget() command.
     * @return a Map2DLocation containing data of the current target.
     * @return true if a target is currently available, false otherwise (in this case returned target is invalid)

--- a/src/navigationDevices/robotGotoDevice/robotGotoDev.cpp
+++ b/src/navigationDevices/robotGotoDevice/robotGotoDev.cpp
@@ -244,6 +244,12 @@ bool robotGotoDev::gotoTargetByRelativeLocation(double x, double y)
     return b;
 }
 
+bool robotGotoDev::followPath(const yarp::dev::Nav2D::Map2DPath& path)
+{
+    yCError(GOTO_DEV) << "Not yet implemented";
+    return false;
+}
+
 bool robotGotoDev::stopNavigation()
 {
     bool b=gotoThread->stopMovement();

--- a/src/navigationDevices/robotGotoDevice/robotGotoDev.h
+++ b/src/navigationDevices/robotGotoDevice/robotGotoDev.h
@@ -72,6 +72,7 @@ public:
     bool gotoTargetByAbsoluteLocation(yarp::dev::Nav2D::Map2DLocation loc) override;
     bool gotoTargetByRelativeLocation(double x, double y, double theta) override;
     bool gotoTargetByRelativeLocation(double x, double y) override;
+    bool followPath(const yarp::dev::Nav2D::Map2DPath& path) override;
     bool getAbsoluteLocationOfCurrentTarget(yarp::dev::Nav2D::Map2DLocation& target) override;
     bool getRelativeLocationOfCurrentTarget(double& x, double& y, double& theta) override;
     bool getNavigationStatus(yarp::dev::Nav2D::NavigationStatusEnum& status) override;

--- a/src/navigationDevices/robotPathPlannerDevice/robotPathPlannerDev.cpp
+++ b/src/navigationDevices/robotPathPlannerDevice/robotPathPlannerDev.cpp
@@ -24,6 +24,7 @@
  * A detailed description of configuration parameters available for the module is provided in the README.md file.
  */
 
+#include <yarp/os/Log.h>
 #include <yarp/os/Network.h>
 #include <yarp/os/RFModule.h>
 #include <yarp/os/Time.h>
@@ -153,6 +154,12 @@ bool robotPathPlannerDev::gotoTargetByRelativeLocation(double x, double y, doubl
     b &= m_plannerThread->setNewRelTarget(v);
     m_plannerThread->resetAttemptCounter();
     return b;
+}
+
+bool robotPathPlannerDev::followPath(const Map2DPath& path)
+{
+    yError("robotPathPlannerDev::goThroughTargetsByAbsoluteLocations() not implemented yet");
+    return false;
 }
 
 bool robotPathPlannerDev::recomputeCurrentNavigationPath()

--- a/src/navigationDevices/robotPathPlannerDevice/robotPathPlannerDev.h
+++ b/src/navigationDevices/robotPathPlannerDevice/robotPathPlannerDev.h
@@ -62,6 +62,7 @@ public:
     bool gotoTargetByAbsoluteLocation(yarp::dev::Nav2D::Map2DLocation loc) override;
     bool gotoTargetByRelativeLocation(double x, double y, double theta) override;
     bool gotoTargetByRelativeLocation(double x, double y) override;
+    bool followPath(const yarp::dev::Nav2D::Map2DPath& path) override;
     bool getAbsoluteLocationOfCurrentTarget(yarp::dev::Nav2D::Map2DLocation& target) override;
     bool getRelativeLocationOfCurrentTarget(double& x, double& y, double& theta) override;
     bool getNavigationStatus(yarp::dev::Nav2D::NavigationStatusEnum& status) override;

--- a/src/navigationDevices/ros2Navigator/ros2Navigator.h
+++ b/src/navigationDevices/ros2Navigator/ros2Navigator.h
@@ -26,11 +26,13 @@
 #include <yarp/dev/INavigation2D.h>
 #include <yarp/dev/ILocalization2D.h>
 #include <yarp/dev/IMap2D.h>
+#include <yarp/dev/Map2DPath.h>
 #include <mutex>
 
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
 #include <nav2_msgs/action/navigate_to_pose.hpp>
+#include <nav2_msgs/action/navigate_through_poses.hpp>
 #include <nav_msgs/msg/path.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <yarp/math/Math.h>
@@ -82,6 +84,7 @@ protected:
     Ros2Spinner *m_innerSpinner{nullptr};
     rclcpp::Node::SharedPtr m_node{nullptr};
     rclcpp_action::Client<nav2_msgs::action::NavigateToPose>::SharedPtr client_ptr_;
+    rclcpp_action::Client<nav2_msgs::action::NavigateThroughPoses>::SharedPtr nav_through_pose_client_ptr_;
     rclcpp::Subscription<nav_msgs::msg::Path>::SharedPtr m_ros2Subscriber_globalPath;
     rclcpp::Subscription<nav_msgs::msg::Path>::SharedPtr m_ros2Subscriber_localPath;
     rclcpp::Subscription<nav2_msgs::action::NavigateToPose::Impl::FeedbackMessage>::SharedPtr navigation_feedback_sub_;
@@ -124,6 +127,13 @@ public:
      * @return true/false if the command is accepted
      */
     bool gotoTargetByRelativeLocation(double x, double y) override;
+
+    /**
+     * Ask the robot to pass through a set of locations defined in the world reference frame
+     * @param locs the locations to be reached
+     * @return true/false
+    */
+    bool followPath(const yarp::dev::Nav2D::Map2DPath& path) override;
 
     /**
      * //Gets the last target set through a setNewAbsTarget() command.


### PR DESCRIPTION
This PR allows to navigate through poses using the underlined nav2 implementation (https://docs.nav2.org/behavior_trees/trees/nav_through_poses_recovery.html). Essentially, by specifying a predefined path in locations.ini the robot will navigate smoothly through the defined poses without stopping. 

### Added:
- PathFollowing in ros2Navigator and interfaces

Related PR in YARP https://github.com/robotology/yarp/pull/3128