### PR TITLE
Ros2 /goal_pose to INav2D command bridge

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016 iCub Facility - IIT Istituto Italiano di Tecnologia 
+# Copyright (C) 2016 iCub Facility - IIT Istituto Italiano di Tecnologia
 # Author: Marco Randazzo marco.randazzo@iit.it
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
 #
@@ -29,6 +29,9 @@ add_subdirectory(follower)
 add_subdirectory(tests)
 add_subdirectory(tutorials)
 add_subdirectory(freeFloorViewer)
+if(NAVIGATION_USE_ROS2)
+    add_subdirectory(ros2_utilities)
+endif()
 
 #add_subdirectory(extendedRangefinder2DWrapper)  da mettere???
 

--- a/src/ros2_utilities/CMakeLists.txt
+++ b/src/ros2_utilities/CMakeLists.txt
@@ -1,0 +1,9 @@
+#
+# Copyright (C) 2022 Istituto Italiano di Tecnologia (IIT)
+# All rights reserved.
+#
+# This software may be modified and distributed under the terms of the
+# GPL-2+ license. See the accompanying LICENSE file for details.
+#
+
+add_subdirectory(ros2GoalPoseRedirector)

--- a/src/ros2_utilities/ros2GoalPoseRedirector/CMakeLists.txt
+++ b/src/ros2_utilities/ros2GoalPoseRedirector/CMakeLists.txt
@@ -1,0 +1,23 @@
+#
+# Copyright (C) 2016 iCub Facility - IIT Istituto Italiano di Tecnologia
+# Author: Ettore Landini ettore.landini@iit.it
+# CopyPolicy: Released under the terms of the GNU GPL v2.0.
+#
+
+project(ros2GoalPoseRedirector)
+
+file(GLOB folder_source *.cpp)
+file(GLOB folder_header *.h)
+
+source_group("Source Files" FILES ${folder_source})
+source_group("Header Files" FILES ${folder_header})
+
+
+include_directories(${OpenCV_INCLUDE_DIRS} ${ICUB_INCLUDE_DIRS})
+add_executable(${PROJECT_NAME} ${folder_source} ${folder_header})
+target_link_libraries(${PROJECT_NAME} ${OpenCV_LIBRARIES} ${YARP_LIBRARIES}
+    rclcpp::rclcpp
+    std_msgs::std_msgs__rosidl_typesupport_cpp
+    geometry_msgs::geometry_msgs__rosidl_typesupport_cpp)
+set_property(TARGET ${PROJECT_NAME} PROPERTY FOLDER "Modules")
+install(TARGETS ${PROJECT_NAME} DESTINATION bin)

--- a/src/ros2_utilities/ros2GoalPoseRedirector/Ros2GoalPoseRedirector.cpp
+++ b/src/ros2_utilities/ros2GoalPoseRedirector/Ros2GoalPoseRedirector.cpp
@@ -1,0 +1,109 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "Ros2GoalPoseRedirector.h"
+
+#ifndef RAD2DEG
+#define RAD2DEG 180.0 / M_PI
+#endif
+
+YARP_LOG_COMPONENT(ROS2_GOAL_POSE_REDIRECTOR, "navigation.ros2GoalPoseRedirector")
+
+Ros2GoalPoseRedirector::Ros2GoalPoseRedirector() :
+    m_period(1.0)
+{
+}
+
+bool Ros2GoalPoseRedirector::configure(yarp::os::ResourceFinder &rf)
+{
+    if(rf.check("period")){m_period = rf.find("period").asFloat32();}
+
+    m_name = "/ros2GoalPoseRedirector";
+    if(rf.check("name")){m_name = rf.find("name").asString();}
+
+    m_nodeName = "yarp_ros2_goal_pose_redirector";
+    if(rf.check("node_name")){m_nodeName = rf.find("node_name").asString();}
+
+    m_topicName = "/goal_pose";
+    if(rf.check("topic_name")){m_topicName = rf.find("topic_name").asString();}
+
+    yarp::os::Network::init();
+
+    m_node = rclcpp::Node::make_shared(m_nodeName);
+
+    if(!m_node)
+    {
+        yCError(ROS2_GOAL_POSE_REDIRECTOR) << "Failed to create ROS2 node";
+        return false;
+    }
+
+    if(!rf.check("NAVIGATION_CLIENT"))
+    {
+        yCError(ROS2_GOAL_POSE_REDIRECTOR) << "Missing nav2d section in configuration file";
+        return false;
+    }
+    if(!m_nav2DPoly.open(rf.findGroup("NAVIGATION_CLIENT")))
+    {
+        yCError(ROS2_GOAL_POSE_REDIRECTOR) << "Failed to open nav2d polydriver";
+        return false;
+    }
+
+    if(!m_nav2DPoly.isValid())
+    {
+        yCError(ROS2_GOAL_POSE_REDIRECTOR) << "Failed to open nav2d polydriver";
+        return false;
+    }
+
+    m_nav2DPoly.view(m_iNav2D);
+
+    if(!m_iNav2D)
+    {
+        yCError(ROS2_GOAL_POSE_REDIRECTOR) << "Failed to view INavigation2D interface";
+        return false;
+    }
+
+    m_goalPoseSub = m_node->create_subscription<geometry_msgs::msg::PoseStamped>(
+        m_topicName,
+        10,
+        std::bind(&Ros2GoalPoseRedirector::goalPoseCallback, this, std::placeholders::_1));
+
+    return true;
+}
+
+bool Ros2GoalPoseRedirector::close()
+{
+    m_nav2DPoly.close();
+    m_node.reset();
+    yarp::os::Network::fini();
+    return true;
+}
+
+double Ros2GoalPoseRedirector::getPeriod()
+{
+    return m_period;
+}
+
+bool Ros2GoalPoseRedirector::updateModule()
+{
+    rclcpp::spin(m_node);
+    return true;
+}
+
+void Ros2GoalPoseRedirector::goalPoseCallback(const geometry_msgs::msg::PoseStamped::SharedPtr msg)
+{
+    yCInfo(ROS2_GOAL_POSE_REDIRECTOR) << "Received goal pose: " << msg->pose.position.x << " " << msg->pose.position.y;
+    yarp::math::Quaternion q;
+    q.x() = msg->pose.orientation.x;
+    q.y() = msg->pose.orientation.y;
+    q.z() = msg->pose.orientation.z;
+    q.w() = msg->pose.orientation.w;
+    yarp::sig::Vector v = q.toAxisAngle();
+    double t = v[3]*v[2];
+    yarp::dev::Nav2D::Map2DLocation goal;
+    goal.x = msg->pose.position.x;
+    goal.y = msg->pose.position.y;
+    goal.theta = t * RAD2DEG;
+    m_iNav2D->gotoTargetByAbsoluteLocation(goal);
+}

--- a/src/ros2_utilities/ros2GoalPoseRedirector/Ros2GoalPoseRedirector.h
+++ b/src/ros2_utilities/ros2GoalPoseRedirector/Ros2GoalPoseRedirector.h
@@ -1,0 +1,63 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef ROS2GOALPOSEREDIRECTOR_H
+#define ROS2GOALPOSEREDIRECTOR_H
+
+#include <yarp/os/Network.h>
+#include <yarp/os/RFModule.h>
+#include <yarp/os/Time.h>
+#include <yarp/os/Port.h>
+#include <yarp/os/Log.h>
+#include <yarp/math/Quaternion.h>
+#include <yarp/os/LogStream.h>
+#include <yarp/dev/PolyDriver.h>
+#include <yarp/dev/INavigation2D.h>
+#include <yarp/dev/Map2DLocationData.h>
+#include <rclcpp/rclcpp.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+
+
+/**
+ * @ingroup
+ *
+ * @brief This class is a YARP RFModule that redirects goal poses from a ROS2 topic to a YARP INavigation2D interface.
+ * \section Parameters
+ * |Group             |Parameter          |Type    |Units|Default                        |Description                                       |
+ * |------------------|-------------------|--------|-----|-------------------------------|--------------------------------------------------|
+ * |NAVIGATION_CLIENT |device             | string |     |                               |Device name of the INavigation2D interface        |
+ * |NAVIGATION_CLIENT |local              | string |     |                               |Local port name of the INavigation2D interface    |
+ * |NAVIGATION_CLIENT |remote navigation  | string |     |                               |Remote port name of the INavigation2D interface   |
+ * |NAVIGATION_CLIENT |remote map         | string |     |                               |Remote port name of the IMap2D interface          |
+ * |NAVIGATION_CLIENT |remote localizer   | string |     |                               |Remote port name of the ILocalization2D interface |
+ * |                  |period             | double |s    |1.0                            |Module period                                     |
+ * |                  |name               | string |     |/ros2GoalPoseRedirector        |Module name                                       |
+ * |                  |node_name          | string |     |yarp_ros2_goal_pose_redirector |ROS2 node name                                    |
+ * |                  |topic_name         | string |     |/goal_pose                     |ROS2 topic name                                   |
+ *
+ */
+
+class Ros2GoalPoseRedirector : public yarp::os::RFModule
+{
+protected:
+    double                   m_period;
+    std::string              m_name;
+    std::string              m_nodeName;
+    std::string              m_topicName;
+    rclcpp::Node::SharedPtr  m_node;
+    yarp::dev::PolyDriver            m_nav2DPoly;
+    yarp::dev::Nav2D::INavigation2D *m_iNav2D{nullptr};
+    rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr m_goalPoseSub;
+
+public:
+    Ros2GoalPoseRedirector();
+    virtual bool configure(yarp::os::ResourceFinder &rf);
+    virtual bool close();
+    virtual double getPeriod();
+    virtual bool updateModule();
+    void goalPoseCallback(const geometry_msgs::msg::PoseStamped::SharedPtr msg);
+};
+
+#endif // ROS2GOALPOSEREDIRECTOR_H

--- a/src/ros2_utilities/ros2GoalPoseRedirector/main.cpp
+++ b/src/ros2_utilities/ros2GoalPoseRedirector/main.cpp
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+
+#include <yarp/os/Network.h>
+#include "Ros2GoalPoseRedirector.h"
+
+int main(int argc, char *argv[])
+{
+    yarp::os::Network yarp;
+    if (!yarp.checkNetwork())
+    {
+        yError("check Yarp network.\n");
+        return -1;
+    }
+
+    yarp::os::ResourceFinder rf;
+    rf.setVerbose(true);
+    rf.setDefaultConfigFile("redirector_def.ini");           //overridden by --from parameter
+    rf.setDefaultContext("ros2GoalPoseRedirector");          //overridden by --context parameter
+    rf.configure(argc,argv);
+    //std::string debug_rf = rf.toString();
+    Ros2GoalPoseRedirector redirector;
+
+    return redirector.runModule(rf);
+}


### PR DESCRIPTION
This PR introduces a simple module that can intercept a `ROS2` navigation goal pose and send it to a `yarp::dev::INav2D` device. This can help use yarp based navigation devices with `ROS2` tools like `rviz2` 