### PR TITLE
Fixed goto_target_by_relative_location

### DIFF
--- a/src/navigationDevices/ros2Navigator/ros2Navigator.cpp
+++ b/src/navigationDevices/ros2Navigator/ros2Navigator.cpp
@@ -337,19 +337,22 @@ yarp::dev::ReturnValue ros2Navigator::gotoTargetByAbsoluteLocation(Map2DLocation
 yarp::dev::ReturnValue ros2Navigator::gotoTargetByRelativeLocation(double x, double y, double theta)
 {
     Map2DLocation loc;
+    double a = m_current_position.theta * DEG2RAD;
     loc.map_id = m_current_position.map_id;
-    loc.x = m_current_position.x + x;
-    loc.y = m_current_position.y + y;
+    loc.x = x * cos(a) - y * sin(a) + m_current_position.x;
+    loc.y = x * sin(a) + y * cos(a) + m_current_position.y;
     loc.theta = m_current_position.theta + theta;
+
     return gotoTargetByAbsoluteLocation(loc);
 }
 
 yarp::dev::ReturnValue ros2Navigator::gotoTargetByRelativeLocation(double x, double y)
 {
     Map2DLocation loc;
+    double a = m_current_position.theta * DEG2RAD;
     loc.map_id = m_current_position.map_id;
-    loc.x = m_current_position.x + x;
-    loc.y = m_current_position.y + y;
+    loc.x = x * cos(a) - y * sin(a) + m_current_position.x;
+    loc.y = x * sin(a) + y * cos(a) + m_current_position.y;
     loc.theta = m_current_position.theta;
     return gotoTargetByAbsoluteLocation(loc);
 }

--- a/src/navigationDevices/ros2Navigator/ros2Navigator.h
+++ b/src/navigationDevices/ros2Navigator/ros2Navigator.h
@@ -32,6 +32,13 @@
 
 #define DEFAULT_THREAD_PERIOD 0.02 // s
 
+#ifndef M_PI
+#define M_PI 3.14159265
+#endif
+
+const double RAD2DEG = 180.0 / M_PI;
+const double DEG2RAD = M_PI / 180.0;
+
 class ros2Navigator : public yarp::dev::DeviceDriver,
                       public yarp::os::PeriodicThread,
                       public yarp::dev::Nav2D::INavigation2DTargetActions,


### PR DESCRIPTION
Now the method `goto_target_by_relative_location` uses the robot current orientation to calculate the new absolute location.